### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/huggingface/spaces/openai-tts/app.py
+++ b/huggingface/spaces/openai-tts/app.py
@@ -52,6 +52,9 @@ def tts(
             speed=speed,
         )
         # Save the audio content to a temporary file
+        allowed_formats = ["mp3", "opus", "aac", "flac", "wav"]
+        if response_format not in allowed_formats:
+            raise ValueError(f"Invalid response format: {response_format}")
         file_extension = f".{response_format}"
         with tempfile.NamedTemporaryFile(
             suffix=file_extension, delete=False, mode="wb"


### PR DESCRIPTION
Fixes [https://github.com/aai540-group3/project/security/code-scanning/1](https://github.com/aai540-group3/project/security/code-scanning/1)

To fix the problem, we need to validate the `response_format` parameter to ensure it only contains allowed values before using it to construct the `file_extension`. This can be done by checking if the `response_format` is in the predefined list of safe options. If it is not, we should raise an error.

1. Add a validation step to check if `response_format` is in the list of allowed formats.
2. Raise an error if the `response_format` is not valid.
3. Ensure this validation is done before constructing the `file_extension`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
