### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/huggingface/spaces/openai-tts/app.py
+++ b/huggingface/spaces/openai-tts/app.py
@@ -53,6 +53,7 @@ def tts(
         )
         # Save the audio content to a temporary file
         allowed_formats = ["mp3", "opus", "aac", "flac", "wav"]
+        response_format = response_format.lower()
         if response_format not in allowed_formats:
             raise ValueError(f"Invalid response format: {response_format}")
         file_extension = f".{response_format}"


### PR DESCRIPTION
Fixes [https://github.com/aai540-group3/project/security/code-scanning/1](https://github.com/aai540-group3/project/security/code-scanning/1)

To fix the problem, we need to ensure that the `response_format` is strictly validated against a predefined list of allowed formats before it is used to construct the file path. This can be achieved by checking the `response_format` value and raising an error if it is not in the allowed list. This validation should be done before constructing the `file_extension` and using it in the `tempfile.NamedTemporaryFile` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
