### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/huggingface/spaces/openai-tts/app.py
+++ b/huggingface/spaces/openai-tts/app.py
@@ -3,7 +3,7 @@ from functools import partial
 
 import gradio as gr
 import openai
-
+from werkzeug.utils import secure_filename
 
 def tts(
     input_text: str,
@@ -53,7 +53,7 @@ def tts(
         )
         # Save the audio content to a temporary file
         allowed_formats = ["mp3", "opus", "aac", "flac", "wav"]
-        response_format = response_format.lower()
+        response_format = secure_filename(response_format.lower())
         if response_format not in allowed_formats:
             raise ValueError(f"Invalid response format: {response_format}")
         file_extension = f".{response_format}"


### PR DESCRIPTION
Fixes [https://github.com/aai540-group3/project/security/code-scanning/1](https://github.com/aai540-group3/project/security/code-scanning/1)

To fix the problem, we need to ensure that the `response_format` value is not only checked against a list of allowed formats but also sanitized to prevent any potential path traversal or injection attacks. We can achieve this by using the `werkzeug.utils.secure_filename` function to sanitize the `response_format` value before using it to construct the file path.

1. Import the `secure_filename` function from `werkzeug.utils`.
2. Use the `secure_filename` function to sanitize the `response_format` value before constructing the `file_extension`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
